### PR TITLE
Add precommit hook to run tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -241,7 +241,7 @@
     },
     "http-status": {
       "version": "0.2.0",
-      "from": "http-status@*",
+      "from": "https://registry.npmjs.org/http-status/-/http-status-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/http-status/-/http-status-0.2.0.tgz"
     },
     "morgan": {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
     "mocha": "^2.2.5",
     "mocha-eslint": "^1.0.0",
     "mocha-istanbul": "^0.2.0",
-    "proxyquire": "^1.7.1"
+    "proxyquire": "^1.7.1",
+    "pre-commit": "^1.1.1"
   },
   "dependencies": {
     "express": "^4.13.3",
     "http-status": "^0.2.0",
     "morgan": "^1.6.1"
-  }
+  },
+  "pre-commit": ["test"]
 }


### PR DESCRIPTION
This way you have no excuse for not running the tests, and we keep the tests fast (because they'll annoy you otherwise).
